### PR TITLE
StringBuffer replaced by StringBuilder; bugfix for removing new line characters

### DIFF
--- a/src/main/java/com/fordfrog/xml2csv/ColumnFinder.java
+++ b/src/main/java/com/fordfrog/xml2csv/ColumnFinder.java
@@ -103,13 +103,13 @@ public class ColumnFinder {
 	if (list.size() == 0) {
 	    return "";
 	}
-	StringBuffer buffer = new StringBuffer();
-	buffer.append(list.get(0));
+	StringBuilder sb = new StringBuilder();
+	sb.append(list.get(0));
 	for (int i = 1; i < list.size(); i++) {
-	    buffer.append(',');
-	    buffer.append(list.get(i));
+	    sb.append(',');
+	    sb.append(list.get(i));
 	}
-	return buffer.toString();
+	return sb.toString();
     }
 
     /**

--- a/src/main/java/com/fordfrog/xml2csv/Convertor.java
+++ b/src/main/java/com/fordfrog/xml2csv/Convertor.java
@@ -208,9 +208,6 @@ public class Convertor {
                     processItem(reader, writer, columns, filters, remappings, separator, trim, join, currentElementPath, values, itemName);
                     break;
                 case XMLStreamReader.CHARACTERS:
-                    if (reader.isWhiteSpace()){
-                        break;
-                    }
                     sb.append(reader.getText());
                     break;
                 case XMLStreamReader.END_ELEMENT:

--- a/src/main/java/com/fordfrog/xml2csv/Convertor.java
+++ b/src/main/java/com/fordfrog/xml2csv/Convertor.java
@@ -199,7 +199,7 @@ public class Convertor {
             final Writer writer, final String[] columns, final Filters filters,
             final Remappings remappings, final char separator, final boolean trim, final boolean join, final String parentElement, final Map<String, List<String>> values, final String itemName) throws XMLStreamException,
             IOException {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
 
         while (reader.hasNext()) {
             switch (reader.next()) {
@@ -211,7 +211,7 @@ public class Convertor {
                     if (reader.isWhiteSpace()){
                         break;
                     }
-                    buffer.append(reader.getText());
+                    sb.append(reader.getText());
                     break;
                 case XMLStreamReader.END_ELEMENT:
                     if ((parentElement).compareTo(itemName) == 0) {
@@ -227,7 +227,7 @@ public class Convertor {
                             writeRow(writer, columns, singleValues, separator);
                         }
                       } else {
-                          processValue(parentElement.replaceFirst(Pattern.quote(itemName + "/"), ""), buffer.toString(), values);                      
+                          processValue(parentElement.replaceFirst(Pattern.quote(itemName + "/"), ""), sb.toString(), values);                      
                       }
                     return;
             }
@@ -273,18 +273,18 @@ public class Convertor {
             return null;
         }
         if (join) {
-            StringBuffer stringBuffer = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             for (int i = 0; i < values.size(); i++) {
                 String value = values.get(i);
                 if (trim) {
                     value = value.trim();
                 }
-                stringBuffer.append(value);
+                sb.append(value);
                 if (i < values.size() - 1) {
-                    stringBuffer.append(valueSeparator);
+                    sb.append(valueSeparator);
                 }
             }
-            return stringBuffer.toString();
+            return sb.toString();
         } else {
             String value = values.get(0);
             return trim ? value.trim() : value;

--- a/src/test/java/com/fordfrog/xml2csv/ConvertorTest.java
+++ b/src/test/java/com/fordfrog/xml2csv/ConvertorTest.java
@@ -2,6 +2,7 @@ package com.fordfrog.xml2csv;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -35,6 +36,24 @@ public class ConvertorTest {
         String expected = readFile(outputFile, StandardCharsets.UTF_8);
 
         assertEquals(expected, writer.toString());
+    }
+    
+    @Test
+    public void testConvertNewLines()
+            throws IOException, URISyntaxException {
+        Writer writer = new StringWriter();
+        Convertor.convert(new ByteArrayInputStream("<r><i><v>1\n1</v></i></r>".getBytes()), writer, new String[] { "v" }, null, null, ';', false, false, "/r/i");
+
+        assertEquals("\"v\"\n\"1\n1\"\n", writer.toString());
+    }
+
+    @Test
+    public void testConvertNewLinesBetweenXMLEscape()
+            throws IOException, URISyntaxException {
+        Writer writer = new StringWriter();
+        Convertor.convert(new ByteArrayInputStream("<r><i><v>&lt;p /&gt;\n&lt;p /&gt;</v></i></r>".getBytes()), writer, new String[] { "v" }, null, null, ';', false, false, "/r/i");
+
+        assertEquals("\"v\"\n\"<p />\n<p />\"\n", writer.toString());
     }
     
     @Test


### PR DESCRIPTION
This pull request contains: 
- change - StringBuilder is preferred over StringBuffer - usage of StringBuffer is replaced by StringBuilder
- bugfix - new line characters in text of an XML element were removed when these new lines were between XML escape entities
