### PR TITLE
Fix compile errors on JDK 21 on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ be converted.
 
 ## Prerequisities
 
-* JRE or JDK 7+
+* JRE or JDK 8+
 * Apache Maven 3+ (just in case you want to compile the application yourself)
 
 ## Compilation

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                     <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
@@ -41,9 +41,9 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>[4.11,5.0-SNAPSHOT)</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/fordfrog/xml2csv/Convertor.java
+++ b/src/main/java/com/fordfrog/xml2csv/Convertor.java
@@ -21,10 +21,12 @@
  */
 package com.fordfrog.xml2csv;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -62,9 +64,9 @@ public class Convertor {
             final String[] columns, final Filters filters,
             final Remappings remappings, final char separator,
             final boolean trim, final boolean join, final String itemName) {
-        try (final InputStream inputStream = Files.newInputStream(inputFile);
+        try (final InputStream inputStream = new BufferedInputStream(Files.newInputStream(inputFile));
                 final Writer writer = Files.newBufferedWriter(
-                        outputFile, Charset.forName("UtF-8"))) {
+                        outputFile, StandardCharsets.UTF_8)) {
             convert(inputStream, writer, columns, filters, remappings, separator,
                     trim, join, itemName);
         } catch (final IOException ex) {

--- a/src/test/java/com/fordfrog/xml2csv/ColumnFinderTest.java
+++ b/src/test/java/com/fordfrog/xml2csv/ColumnFinderTest.java
@@ -24,8 +24,9 @@ package com.fordfrog.xml2csv;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Assert;
-import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class ColumnFinderTest {
 
@@ -33,7 +34,7 @@ public class ColumnFinderTest {
     public void test() {
         final InputStream inputStream = this.getClass().getResourceAsStream(
                 "/input-columns.xml");
-        Assert.assertNotNull(inputStream);
+        assertNotNull(inputStream);
 
         final List<String> expected = Arrays.asList(
                 new String[]{"item1/item2/value1", "value2", "value3", "value4"});
@@ -41,6 +42,6 @@ public class ColumnFinderTest {
         final List<String> columns = ColumnFinder.find(inputStream,
                 "/root/item/");
 
-        Assert.assertEquals(expected, columns);
+        assertEquals(expected, columns);
     }
 }

--- a/src/test/java/com/fordfrog/xml2csv/ConvertorTest.java
+++ b/src/test/java/com/fordfrog/xml2csv/ConvertorTest.java
@@ -22,6 +22,7 @@
 package com.fordfrog.xml2csv;
 
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -29,23 +30,23 @@ import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import org.junit.Assert;
-import org.junit.Test;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class ConvertorTest {
 
     String readFile(String path, Charset encoding)
             throws IOException {
-        final byte[] encoded = Files.readAllBytes(Paths.get(this.getClass().
-                getResource(path).getFile()));
-
-        return encoding.decode(ByteBuffer.wrap(encoded)).toString();
+        try (InputStream in = this.getClass().getResourceAsStream(path)) {
+            byte[] encoded = in.readAllBytes();
+            return encoding.decode(ByteBuffer.wrap(encoded)).toString();
+        }
     }
 
     @Test
-    public void testConvertSiple()
+    public void testConvertSimple()
             throws IOException, URISyntaxException {
         final String inputFile = "/input-simple.xml";
         final String outputFile = "/output-simple.csv";
@@ -57,7 +58,10 @@ public class ConvertorTest {
 
         final String expected = readFile(outputFile, StandardCharsets.UTF_8);
 
-        Assert.assertEquals(expected, writer.toString());
+        assertLinesMatch(
+            List.of(expected.split("\\R")),
+            List.of(writer.toString().split("\\R"))
+        );
     }
 
     @Test
@@ -69,7 +73,7 @@ public class ConvertorTest {
                 getBytes()), writer, new String[]{"v"}, null, null, ';', false,
                 false, "/r/i");
 
-        Assert.assertEquals("\"v\"\n\"1\n1\"\n", writer.toString());
+        assertEquals("\"v\"\n\"1\n1\"\n", writer.toString());
     }
 
     @Test
@@ -81,7 +85,7 @@ public class ConvertorTest {
                 "<r><i><v>&lt;p /&gt;\n&lt;p /&gt;</v></i></r>".getBytes()),
                 writer, new String[]{"v"}, null, null, ';', false, false, "/r/i");
 
-        Assert.assertEquals("\"v\"\n\"<p />\n<p />\"\n", writer.toString());
+        assertEquals("\"v\"\n\"<p />\n<p />\"\n", writer.toString());
     }
 
     @Test
@@ -97,7 +101,10 @@ public class ConvertorTest {
 
         final String expected = readFile(outputFile, StandardCharsets.UTF_8);
 
-        Assert.assertEquals(expected, writer.toString());
+        assertLinesMatch(
+            List.of(expected.split("\\R")),
+            List.of(writer.toString().split("\\R"))
+        );
     }
 
     @Test
@@ -113,7 +120,10 @@ public class ConvertorTest {
 
         final String expected = readFile(outputFile, StandardCharsets.UTF_8);
 
-        Assert.assertEquals(expected, writer.toString());
+        assertLinesMatch(
+            List.of(expected.split("\\R")),
+            List.of(writer.toString().split("\\R"))
+        );
     }
 
     @Test
@@ -129,7 +139,10 @@ public class ConvertorTest {
 
         final String expected = readFile(outputFile, StandardCharsets.UTF_8);
 
-        Assert.assertEquals(expected, writer.toString());
+        assertLinesMatch(
+            List.of(expected.split("\\R")),
+            List.of(writer.toString().split("\\R"))
+        );
     }
 
     @Test
@@ -145,7 +158,10 @@ public class ConvertorTest {
 
         final String expected = readFile(outputFile, StandardCharsets.UTF_8);
 
-        Assert.assertEquals(expected, writer.toString());
+        assertLinesMatch(
+            List.of(expected.split("\\R")),
+            List.of(writer.toString().split("\\R"))
+        );
     }
 
     @Test
@@ -162,6 +178,9 @@ public class ConvertorTest {
 
         final String expected = readFile(outputFile, StandardCharsets.UTF_8);
 
-        Assert.assertEquals(expected, writer.toString());
+        assertLinesMatch(
+            List.of(expected.split("\\R")),
+            List.of(writer.toString().split("\\R"))
+        );
     }
 }

--- a/src/test/java/com/fordfrog/xml2csv/CsvUtilsTest.java
+++ b/src/test/java/com/fordfrog/xml2csv/CsvUtilsTest.java
@@ -21,8 +21,8 @@
  */
 package com.fordfrog.xml2csv;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link CsvUtils}.
@@ -33,27 +33,27 @@ public class CsvUtilsTest {
 
     @Test
     public void tests() {
-        Assert.assertArrayEquals(new String[]{"test", "test"},
+        assertArrayEquals(new String[]{"test", "test"},
                 CsvUtils.parseValues("test,test"));
-        Assert.assertArrayEquals(new String[]{"test", "test"},
+        assertArrayEquals(new String[]{"test", "test"},
                 CsvUtils.parseValues("\"test\",test"));
-        Assert.assertArrayEquals(new String[]{"test", "test"},
+        assertArrayEquals(new String[]{"test", "test"},
                 CsvUtils.parseValues("\"test\",\"test\""));
-        Assert.assertArrayEquals(new String[]{"test", "test"},
+        assertArrayEquals(new String[]{"test", "test"},
                 CsvUtils.parseValues("'test',test"));
-        Assert.assertArrayEquals(new String[]{"test", "test"},
+        assertArrayEquals(new String[]{"test", "test"},
                 CsvUtils.parseValues("'test','test'"));
-        Assert.assertArrayEquals(new String[]{"test \"", "test"},
+        assertArrayEquals(new String[]{"test \"", "test"},
                 CsvUtils.parseValues("\"test \"\"\",test"));
-        Assert.assertArrayEquals(new String[]{"test '", "test"},
+        assertArrayEquals(new String[]{"test '", "test"},
                 CsvUtils.parseValues("\"test '\",test"));
-        Assert.assertArrayEquals(new String[]{"test \"", "test"},
+        assertArrayEquals(new String[]{"test \"", "test"},
                 CsvUtils.parseValues("\"test \\\"\",test"));
-        Assert.assertArrayEquals(new String[]{"test '", "test"},
+        assertArrayEquals(new String[]{"test '", "test"},
                 CsvUtils.parseValues("'test ''',test"));
-        Assert.assertArrayEquals(new String[]{"test \"", "test"},
+        assertArrayEquals(new String[]{"test \"", "test"},
                 CsvUtils.parseValues("'test \"',test"));
-        Assert.assertArrayEquals(new String[]{"test '", "test"},
+        assertArrayEquals(new String[]{"test '", "test"},
                 CsvUtils.parseValues("'test \\'',test"));
     }
 }


### PR DESCRIPTION
* Update required Java to 8 (targeting 7 not supported anymore)
* Upgrade to JUnit 5 and in particular change ConvertorTest to use assertLinesMatch to fix line ending mismatch errors
* Change Convertor to use BufferedInputStream and fix charset name capitalisation issue (originally written as "UtF-8")
* Fix Windows path prefix problems in readFile function when running unit tests